### PR TITLE
Fix link to app author

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -524,12 +524,12 @@ function Timeline(props: {
           <div className="text-lg mt-2 text-center">
             Try following some more accounts! We wholeheartedly recommend:{" "}
             <a
-              href="https://staging.bsky.app/profile/louis02x.bsky.social"
+              href="https://staging.bsky.app/profile/louis02x.com"
               target="_blank"
               rel="noopener noreferrer"
               className="text-blue-700 dark:text-blue-400"
             >
-              louis02x.bsky.social
+              @louis02x.com
             </a>{" "}
             (it's me lol)
           </div>


### PR DESCRIPTION
This fixes the link to the app author on the empty timeline state.

## :camera_flash: Screenshots

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/28510368/234127519-2c598084-8063-4beb-8b2e-494e74cdb6af.png) | ![image](https://user-images.githubusercontent.com/28510368/234127558-14a587e7-557f-4de0-84be-8515cfe5f70b.png) |